### PR TITLE
Use _.toNumber() over parseInt.

### DIFF
--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -586,7 +586,7 @@ SqlStore.prototype.create = function (request, newResource, finishedCallback) {
     if (newResource.id === 0) {
       delete newResource.id
     } else if (self.config.dialect === 'postgres') {
-      if (!isNaN(parseInt(newResource.id))) {
+      if (!isNaN(_.toNumber(newResource.id))) {
         /*
         If parseInt(newResource.id) is NaN, it means
         it is 'DEFAULT', which is fine.

--- a/lib/sqlHandler.js
+++ b/lib/sqlHandler.js
@@ -588,7 +588,7 @@ SqlStore.prototype.create = function (request, newResource, finishedCallback) {
     } else if (self.config.dialect === 'postgres') {
       if (!isNaN(_.toNumber(newResource.id))) {
         /*
-        If parseInt(newResource.id) is NaN, it means
+        If _.toNumber(newResource.id) is NaN, it means
         it is 'DEFAULT', which is fine.
         If it **is** a number, then we need to
         update the sequence


### PR DESCRIPTION
ParseInt fails to fail on UUIDs that start with a numeric digit. i.e. "7dbeac-...." returns 7 instead of NaN !

Addresses https://github.com/jagql/store-sequelize/issues/26
