### PR TITLE
Feature/support objects as jsonb

### DIFF
--- a/lib/modelGenerators/default.js
+++ b/lib/modelGenerators/default.js
@@ -113,6 +113,19 @@ module.exports = class {
           }
         }
       }
+      if (attribute._type === 'object') {
+        this[attributeName] = {
+          type: DataTypes.STRING,
+          allowNull: true,
+          get: function () {
+            const data = this.getDataValue(attributeName)
+            return data ? JSON.parse(data) : {}
+          },
+          set: function (val) {
+            this.setDataValue(attributeName, JSON.stringify(val))
+          }
+        }
+      }
       if (attribute._flags) {
         if (attribute._flags.presence === 'required') {
           this[attributeName].allowNull = false

--- a/lib/modelGenerators/postgres.js
+++ b/lib/modelGenerators/postgres.js
@@ -60,6 +60,19 @@ module.exports = class extends Default {
           this.setDataValue(attributeName, val || [])
         }
       }
+      if (attribute._type === 'object') {
+        // PostgreSQL has JSONB support, so lets use that
+        this[attributeName] = {
+          type: DataTypes.JSONB,
+          allowNull: true
+        }
+        this[attributeName].get = function () {
+          return this.getDataValue(attributeName) || {}
+        }
+        this[attributeName].set = function (val) {
+          this.setDataValue(attributeName, val || {})
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
A gap in the Joi schema support was Joi.object(). For default, it converts to string, in the same fashion as for array().  For postgres, it saves the object as JSONB, which is the generally recommended field type in the postgreSQL documentation.